### PR TITLE
Set Lambda memory limit

### DIFF
--- a/.chalice/config_example.json
+++ b/.chalice/config_example.json
@@ -11,6 +11,7 @@
       "lambda_functions": {
         "handler": {
           "lambda_timeout": 300,
+          "lambda_memory_size": 256,
           "autogen_policy": false,
           "iam_policy_file": "EnergyLabelerPolicy_example.json"
         }

--- a/.chalice/config_example_single.json
+++ b/.chalice/config_example_single.json
@@ -11,6 +11,7 @@
       "lambda_functions": {
         "handler": {
           "lambda_timeout": 300,
+          "lambda_memory_size": 256,
           "autogen_policy": false,
           "iam_policy_file": "EnergyLabelerPolicySingle_example.json"
         }


### PR DESCRIPTION
When running the Lambda I ran into a killed execution due to the default 128MB of memory being too low. I increased it to 256MB where my execution peaked at 216MB. Should be enough.